### PR TITLE
add parameter parsing on build + parameter getter

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -3,6 +3,7 @@ use failure::Error;
 use job::Job;
 use Jenkins;
 use client::{self, Name, Path};
+use serde_json;
 
 /// Short Build that is used in lists and links from other structs
 #[derive(Debug, Deserialize, Clone)]
@@ -45,7 +46,7 @@ pub enum BuildStatus {
 }
 
 /// A `Build` of a `Job`
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Build {
     /// URL for the build
@@ -68,11 +69,36 @@ pub struct Build {
     pub building: bool,
     /// Which slave was it build on
     pub built_on: String,
+    /// Build parameters
+    pub actions: Vec<Action>,
     /// Build number in string format
     pub id: String,
     /// ID while in the build queue
     pub queue_id: u32,
 }
+
+/// An `Action` on a `Build`
+#[derive(Debug, Deserialize, Clone)]
+pub struct Action {
+    /// The hudson.model.{X}Action (not always present)
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub _class: String,
+    /// Parameters if present
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameters: Vec<Parameter>,
+}
+
+/// A `Parameter` on an `Action`
+#[derive(Debug, Deserialize, Clone)]
+pub struct Parameter {
+    /// The hudson.model.{X}ParameterValue
+    pub _class: String,
+    /// The parameter name
+    pub name: String,
+    /// The parameter value (bool / String usually as indicated by _class)
+    pub value: serde_json::Value,
+}
+
 impl Build {
     /// Get the `Job` from a `Build`
     pub fn get_job(&self, jenkins_client: &Jenkins) -> Result<Job, Error> {
@@ -100,6 +126,16 @@ impl Build {
                 expected: "Build".to_string(),
             }.into())
         }
+    }
+
+    /// Get the build parameters from a `Build`
+    pub fn get_parameters(&self) -> Vec<Parameter> {
+        for a in &self.actions {
+            if a._class == "hudson.model.ParametersAction" {
+                return a.parameters.clone();
+            }
+        }
+        vec![]
     }
 }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -80,9 +80,8 @@ pub struct Build {
 /// An `Action` on a `Build`
 #[derive(Debug, Deserialize, Clone)]
 pub struct Action {
-    /// The hudson.model.{X}Action (not always present)
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub _class: String,
+    /// The hudson.model.{X}Action
+    pub _class: Option<String>,
     /// Parameters if present
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub parameters: Vec<Parameter>,
@@ -131,8 +130,10 @@ impl Build {
     /// Get the build parameters from a `Build`
     pub fn get_parameters(&self) -> Vec<Parameter> {
         for a in &self.actions {
-            if a._class == "hudson.model.ParametersAction" {
-                return a.parameters.clone();
+            if let Some(ref c) = a._class {
+                if c == "hudson.model.ParametersAction" {
+                    return a.parameters.clone();
+                }
             }
         }
         vec![]


### PR DESCRIPTION
An extra independent thing.

Needed to filter jobs based on a parameter property that wasn't parsed.

The types of the embedding `actions` struct are a bit dynamic & dubious, but with enough `serde` `default` attrs we can parse them as well :smile: 