### PR TITLE
job: Add 'builds()' method

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -286,6 +286,10 @@ impl Job {
         pub ref last_build -> &Option<ShortBuild>
     );
     job_common_fields_dispatch!(
+        /// List of builds of the job
+        pub ref builds -> &Vec<ShortBuild>
+    );
+    job_common_fields_dispatch!(
         /// Health report of the project
         pub ref health_report -> &Vec<HealthReport>
     );


### PR DESCRIPTION
This allows to get the list of builds of a job, without needing to
find out the job variant.

Fixes: #8

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>