### PR TITLE
Make display name and timestamp available

### DIFF
--- a/src/build/common.rs
+++ b/src/build/common.rs
@@ -20,6 +20,10 @@ pub struct ShortBuild<T: Build = CommonBuild> {
     pub url: String,
     /// Build number
     pub number: u32,
+    /// Display name for the build
+    pub display_name: Option<String>,
+    /// Timestamp for the build
+    pub timestamp: Option<u64>,
     #[serde(flatten)]
     pub(crate) other_fields: Option<serde_json::Value>,
 


### PR DESCRIPTION
I'd like to be able to access more fields of a build by default (display name / timestamp) so I decided to make this change. If it's not acceptable, that's fine, I can just keep up with my fork ;)