### PR TITLE
Support skipping url encoding for job names

### DIFF
--- a/src/job/builder.rs
+++ b/src/job/builder.rs
@@ -68,12 +68,21 @@ impl<'a, 'b, 'c, 'd> JobBuilder<'a, 'b, 'c, 'd> {
         .into())
     }
 
-    pub(crate) fn new_from_job_name<J>(name: J, jenkins_client: &'b Jenkins) -> Result<Self>
+    pub(crate) fn new_from_job_name<J>(
+        name: J,
+        jenkins_client: &'b Jenkins,
+        name_encoded: bool,
+    ) -> Result<Self>
     where
         J: Into<JobName<'a>>,
     {
+        let job_name = if !name_encoded {
+            Name::Name(name.into().0)
+        } else {
+            Name::UrlEncodedName(name.into().0)
+        };
         Ok(JobBuilder {
-            job_name: Name::Name(name.into().0),
+            job_name,
             jenkins_client,
             delay: None,
             cause: None,

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -47,19 +47,20 @@ impl Jenkins {
     }
 
     /// Build a `Job` from it's `job_name`
-    pub fn build_job<'a, J>(&self, job_name: J) -> Result<ShortQueueItem>
+    pub fn build_job<'a, J>(&self, job_name: J, name_encoded: bool) -> Result<ShortQueueItem>
     where
         J: Into<JobName<'a>>,
     {
-        JobBuilder::new_from_job_name(job_name.into().0, self)?.send()
+        JobBuilder::new_from_job_name(job_name.into().0, self, name_encoded)?.send()
     }
 
     /// Create a `JobBuilder` to setup a build of a `Job` from it's `job_name`
     pub fn job_builder<'a, 'b, 'c, 'd>(
         &'b self,
         job_name: &'a str,
+        name_encoded: bool,
     ) -> Result<JobBuilder<'a, 'b, 'c, 'd>> {
-        JobBuilder::new_from_job_name(job_name, self)
+        JobBuilder::new_from_job_name(job_name, self, name_encoded)
     }
 
     /// Poll SCM of a `Job` from it's `job_name`

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -398,7 +398,7 @@ fn can_build_job_with_delay() {
         .unwrap();
 
     let triggered = jenkins
-        .job_builder("delayed job")
+        .job_builder("delayed job", false)
         .unwrap()
         .with_delay(5000)
         .send();
@@ -428,7 +428,7 @@ fn can_build_job_remotely() {
         .unwrap();
 
     let triggered = jenkins
-        .job_builder("remote job")
+        .job_builder("remote job", false)
         .unwrap()
         .remotely_with_token_and_cause("remote_token", None)
         .unwrap()
@@ -523,7 +523,7 @@ fn can_build_job_with_parameters() {
     };
 
     let triggered = jenkins
-        .job_builder("parameterized job")
+        .job_builder("parameterized job", false)
         .unwrap()
         .with_parameters(&params)
         .unwrap()


### PR DESCRIPTION
What
-- 
* Support skipping url encoding for job names: useful for job names with slashes