### PR TITLE
Allow insecure SSL connections

### DIFF
--- a/src/client_internals/builder.rs
+++ b/src/client_internals/builder.rs
@@ -14,7 +14,7 @@ use crate::client::Result;
 ///#
 ///# fn example_function() {
 ///     let jenkins = JenkinsBuilder::new("http://localhost:8080")
-///         .with_user("user", Some("password"))
+///         .with_user("user", Some("password_or_token"))
 ///         .build()
 ///         .unwrap();
 ///# }

--- a/src/job/common.rs
+++ b/src/job/common.rs
@@ -440,7 +440,7 @@ macro_rules! job_buildable_with_common_fields_and_impl {
                 )*)*
                 private_fields {
                     /// Properties of the job
-                    property: Vec<CommonProperty>,
+                    _property: Vec<CommonProperty>,
                 }
             }
         }

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -8,6 +8,7 @@ mod browser;
 pub use self::browser::*;
 
 /// SCM merge options
+#[allow(dead_code)]
 #[derive(Default, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MergeOptions {


### PR DESCRIPTION
Currently it's not possible to connect to Jenkins instances with privately signed certificate.